### PR TITLE
Scan for open http ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "email": "email dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "node server.js",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@arcjet/next": "^1.0.0-beta.8",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,13 @@
+services:
+  - type: web
+    name: welth
+    env: node
+    plan: free
+    buildCommand: npm ci && npm run build
+    startCommand: npm start
+    healthCheckPath: /
+    envVars:
+      - key: NODE_ENV
+        value: production
+    # Render will automatically set the PORT environment variable
+    # Make sure to add your DATABASE_URL and DIRECT_URL in Render dashboard

--- a/server.js
+++ b/server.js
@@ -4,13 +4,19 @@ const next = require('next');
 
 const dev = process.env.NODE_ENV !== 'production';
 const hostname = '0.0.0.0'; // Bind to all interfaces
-const port = process.env.PORT || 3000;
+const port = parseInt(process.env.PORT, 10) || 3000;
 
-// Prepare the Next.js app
-const app = next({ dev, hostname, port });
+console.log(`Starting server in ${dev ? 'development' : 'production'} mode`);
+console.log(`Hostname: ${hostname}`);
+console.log(`Port: ${port}`);
+
+// Prepare the Next.js app - don't pass hostname and port to Next.js app
+const app = next({ dev });
 const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
+  console.log('Next.js app prepared, creating HTTP server...');
+  
   createServer(async (req, res) => {
     try {
       const parsedUrl = parse(req.url, true);
@@ -22,11 +28,16 @@ app.prepare().then(() => {
     }
   })
     .once('error', (err) => {
-      console.error(err);
+      console.error('Server error:', err);
       process.exit(1);
     })
     .listen(port, hostname, () => {
       console.log(`> Ready on http://${hostname}:${port}`);
+      console.log(`> Environment: ${process.env.NODE_ENV}`);
+      console.log(`> Port from env: ${process.env.PORT}`);
     });
+}).catch((err) => {
+  console.error('Failed to prepare Next.js app:', err);
+  process.exit(1);
 });
 


### PR DESCRIPTION
Configure Next.js app for Render deployment to resolve "No open HTTP ports detected" error.

The previous `server.js` configuration passed `hostname` and `port` directly to the Next.js app initialization, which conflicted with the custom server's explicit binding. This PR also adds a `render.yaml` file to provide Render with the necessary build and start commands and a health check path, ensuring the application correctly exposes its HTTP port. Finally, `package.json` is updated to include Prisma client generation during the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-a929b6fc-7259-4440-a676-b6e9238f4ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a929b6fc-7259-4440-a676-b6e9238f4ab3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

